### PR TITLE
Fix promise beeing passed to onSuccess instead of it's result

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,7 @@ export function loaders<L extends Logic = Logic>(
             if (response && response.then && typeof response.then === 'function') {
               return response
                 .then((asyncResponse: any) => {
-                  onSuccess && onSuccess({ response, actionKey, reducerKey, logic })
+                  onSuccess && onSuccess({ response: asyncResponse, actionKey, reducerKey, logic })
                   logic.actions[`${actionKey}Success`](asyncResponse, payload)
                 })
                 .catch((error: Error) => {


### PR DESCRIPTION
The onSuccess method was being passed the promise from the listener.
As the promise is already resolved at that stage, it would make more sense to pass the result instead.

Changed so that the onSuccess method receives the result of the promise.