### PR TITLE
Trigger onFailure on error raised in onSuccess

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,8 +146,15 @@ export function loaders<L extends Logic = Logic>(
             if (response && response.then && typeof response.then === 'function') {
               return response
                 .then((asyncResponse: any) => {
-                  onSuccess && onSuccess({ response, actionKey, reducerKey, logic })
-                  logic.actions[`${actionKey}Success`](asyncResponse, payload)
+                  try {
+                    onSuccess && onSuccess({ response, actionKey, reducerKey, logic })
+                    logic.actions[`${actionKey}Success`](asyncResponse, payload)
+                  } catch (error: Error){
+                    if (!isBreakpoint(error)) {
+                      onFailure && onFailure({ error, actionKey, reducerKey, logic })
+                      logic.actions[`${actionKey}Failure`](error.message, error)
+                    }
+                  }
                 })
                 .catch((error: Error) => {
                   if (!isBreakpoint(error)) {


### PR DESCRIPTION
Hi!

Allows throwing errors in onSuccess callback, to trigger the onFailure callback.

Don't know if you would like this merged in this plugin, but to explain my use case, i'm working with a library, for making requests, that does not throw errors when the request fails, but it sets the success key in the response to true or false. 

Raising errors in the onSuccess callback could allow to properly recognize if the response was successful or not. 
Another approach would be to create a new callback, that would analyze if the request was successful or not, if you would like I could change it.

Also, I did send a fix in a different pull request for something related, if you want I can make a new pull request with both of those changes.
