### PR TITLE
feat: includes response in onFailure callback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ export type KeaLoadersOptions = {
     reducerKey: string
     logic: BuiltLogic
     error: Error
+    response?: any
   }) => void
 }
 
@@ -151,7 +152,7 @@ export function loaders<L extends Logic = Logic>(
                 })
                 .catch((error: Error) => {
                   if (!isBreakpoint(error)) {
-                    onFailure && onFailure({ error, actionKey, reducerKey, logic })
+                    onFailure && onFailure({ error, actionKey, reducerKey, logic, response })
                     logic.actions[`${actionKey}Failure`](error.message, error)
                   }
                 })


### PR DESCRIPTION
I want to see how easily I can tailor error messages based on types of network failure.

The `Error` isn't guaranteed to have that information

Having `response` would spark joy