### PR TITLE
feat: add reducer for errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kea-loaders",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Action Listener side-effects for Kea",
   "author": "Marius Andra",
   "license": "MIT",

--- a/src/__tests__/loaders.js
+++ b/src/__tests__/loaders.js
@@ -41,7 +41,7 @@ test('loaders work', async () => {
   const unmount = logic.mount()
 
   expect(logic.values.users).toBe(null)
-  expect(Object.keys(logic.values)).toEqual(['users', 'usersLoading'])
+  expect(Object.keys(logic.values)).toEqual(['users', 'usersLoading', 'usersError'])
   expect(Object.keys(logic.actions).sort()).toEqual([
     'loadUsersAsync',
     'loadUsersAsyncFailure',
@@ -215,6 +215,7 @@ test('throwing calls failure', async () => {
 
   logic.actions.loadUsersSync()
   expect(logic.values.users).toEqual(null)
+  expect(logic.values.usersError).toEqual(Error('sync nope'))
   expect(syncListenerRan).toBe('sync nope')
 
   expect(errorList).toEqual(['sync nope'])
@@ -223,6 +224,7 @@ test('throwing calls failure', async () => {
   await delay(10)
 
   expect(logic.values.users).toEqual(null)
+  expect(logic.values.usersError).toEqual(Error('async nope'))
   expect(asyncListenerRan).toBe('async nope')
   expect(errorList).toEqual(['sync nope', 'async nope'])
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,11 +120,15 @@ export function loaders<L extends Logic = Logic>(
       const newReducers: Record<string, [any, any] | any> = {}
       const reducerObject: Record<string, (state: any, payload: any) => any> = {}
       const reducerLoadingObject: Record<string, () => any> = {}
+      const reducerErrorObject: Record<string, (state: any, payload: any) => any> = {}
       Object.keys(loaderActions).forEach((actionKey) => {
         reducerObject[`${actionKey}Success`] = (_, { [reducerKey]: value }) => value
         reducerLoadingObject[`${actionKey}`] = () => true
         reducerLoadingObject[`${actionKey}Success`] = () => false
         reducerLoadingObject[`${actionKey}Failure`] = () => false
+        reducerErrorObject[`${actionKey}`] = () => null
+        reducerErrorObject[`${actionKey}Success`] = () => null
+        reducerErrorObject[`${actionKey}Failure`] = (_, { errorObject }) => errorObject
       })
       if (typeof logic.reducers[reducerKey] === 'undefined') {
         newReducers[reducerKey] = [defaultValue, reducerObject]
@@ -133,6 +137,9 @@ export function loaders<L extends Logic = Logic>(
       }
       if (typeof logic.reducers[`${reducerKey}Loading`] === 'undefined') {
         newReducers[`${reducerKey}Loading`] = [false, reducerLoadingObject]
+      }
+      if (typeof logic.reducers[`${reducerKey}Error`] === 'undefined') {
+        newReducers[`${reducerKey}Error`] = [false, reducerErrorObject]
       }
 
       const newListeners: Record<string, ListenerFunction> = {}


### PR DESCRIPTION
When fetching things from the api, we'd like to display error states. This adds a reducer to make the `errorObject` available for a loader.